### PR TITLE
chore: reUpdate .tmux.conf

### DIFF
--- a/dotfiles/.tmux.conf
+++ b/dotfiles/.tmux.conf
@@ -5,7 +5,7 @@ unbind C-b
 bind-key C-a send-prefix
 
 unbind %
-bind | split-window -h
+bind | split-window -h 
 
 unbind '"'
 bind - split-window -v
@@ -22,3 +22,9 @@ set -g window-status-style bg=yellow
 set -g window-status-current-style bg=red,fg=white
 
 set -g set-clipboard on
+
+setw -g mode-keys vi
+bind-key -T copy-mode-vi v send-keys -X begin-selection
+bind-key -T copy-mode-vi y send-keys -X copy-pipe-and-cancel '''pbcopy'''
+bind-key -T copy-mode-vi Enter send-keys -X copy-pipe-and-cancel '''pbcopy'''
+bind-key -T copy-mode-vi MouseDragEnd1Pane send-keys -X copy-pipe-and-cancel '''pbcopy'''


### PR DESCRIPTION
This pull request introduces enhancements to the `dotfiles/.tmux.conf` configuration file, focusing on improving clipboard integration and enabling Vim-style keybindings in copy mode.

Key changes:

### Clipboard and Copy Mode Enhancements:
* Enabled Vim-style keybindings in copy mode by setting `mode-keys` to `vi`. (`[dotfiles/.tmux.confR25-R30](diffhunk://#diff-fb6c588da66806856f518679e844a8452e324ab8698247834e91651e19d81790R25-R30)`)
* Added key bindings for copy mode (`copy-mode-vi`) to streamline text selection and copying:
  - `v` to begin selection.
  - `y` and `Enter` to copy the selection to the clipboard and exit copy mode.
  - `MouseDragEnd1Pane` to copy the selection with the mouse to the clipboard. (`[dotfiles/.tmux.confR25-R30](diffhunk://#diff-fb6c588da66806856f518679e844a8452e324ab8698247834e91651e19d81790R25-R30)`)